### PR TITLE
Upgrade helm

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,12 +34,27 @@ jobs:
     
       - name: Add Helm repositories
         run: |
-          helm repo add argo https://argoproj.github.io/argo-helm
-          helm repo add jetstack https://charts.jetstack.io
+          helm repo add argoproj       https://argoproj.github.io/argo-helm
+          helm repo add jetstack       https://charts.jetstack.io
+          helm repo add akri           https://project-akri.github.io/akri/
+          helm repo add home-assistant https://pajikos.github.io/home-assistant-helm-chart/
 
       - name: Install Kubeconform plugin
         run: |
           helm plugin install --verify=false https://github.com/jtyr/kubeconform-helm
+
+      - name: Build akri-usb-devices
+        run: |
+          helm dependency build akri-usb-devices/
+
+      - name: Run Kubeconform for akri-usb-devices
+        run: |
+          helm kubeconform --strict --summary \
+             --schema-location default \
+             --schema-location ${{ env.CRDS_CATALOG }} \
+             --schema-location ${{ env.K8S_SCHEMAS }} \
+             --schema-location ${{ env.KUSTOMIZE_SCHEMA }} \
+             akri-usb-devices/
 
       - name: Build ArgoCD
         run: |
@@ -67,6 +82,20 @@ jobs:
              --schema-location ${{ env.K8S_SCHEMAS }} \
              --schema-location ${{ env.KUSTOMIZE_SCHEMA }} \
              cert-manager/
+
+      - name: Build home-assistant
+        run: |
+          helm dependency build home-assistant/
+
+      - name: Run Kubeconform for home-assistant
+        if: always()
+        run: |
+          helm kubeconform --strict --summary \
+             --schema-location default \
+             --schema-location ${{ env.CRDS_CATALOG }} \
+             --schema-location ${{ env.K8S_SCHEMAS }} \
+             --schema-location ${{ env.KUSTOMIZE_SCHEMA }} \
+             home-assistant/
 
   validate-argocd:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,10 +31,19 @@ jobs:
         uses: azure/setup-helm@v4.3.1
         with:
           version: v4.1.4
+    
+      - name: Add Helm repositories
+        run: |
+          helm repo add argo https://argoproj.github.io/argo-helm
+          helm repo add jetstack https://charts.jetstack.io
 
       - name: Install Kubeconform plugin
         run: |
           helm plugin install --verify=false https://github.com/jtyr/kubeconform-helm
+
+      - name: Build ArgoCD
+        run: |
+          helm dependency build argocd/
 
       - name: Run Kubeconform for argocd
         run: |
@@ -44,6 +53,10 @@ jobs:
              --schema-location ${{ env.K8S_SCHEMAS }} \
              --schema-location ${{ env.KUSTOMIZE_SCHEMA }} \
              argocd/
+
+      - name: Build cert-manager
+        run: |
+          helm dependency build cert-manager/
 
       - name: Run Kubeconform for cert-manager
         if: always()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4.3.1
         with:
-          version: v3.19.0
+          version: v4.1.4
 
       - name: Install Kubeconform plugin
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install Kubeconform plugin
         run: |
-          helm plugin install https://github.com/jtyr/kubeconform-helm
+          helm plugin install --verify=false https://github.com/jtyr/kubeconform-helm
 
       - name: Run Kubeconform for argocd
         run: |


### PR DESCRIPTION
* Upgrade Helm from 3.19.0 to 4.1.4
* The Helm upgrade requires adding repositories upfront
* Do `helm dependency build` before kubeconform
* Include build and conforms for akri-ubs-devices and home-assistant